### PR TITLE
Expand test setup to run on OSX as well

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,24 @@ remote-control:
 - `/etc/unbound/root.hints`. NOTE IP address of docker container
 
 ``` text
-.                        3600000      NS    MY.ROOT-SERVERS.NET.
-MY.ROOT-SERVERS.NET.     3600000      A     172.17.0.2
+.                        3600000      NS    primary.root-server.com.
+primary.root-server.com. 3600000      A     172.17.0.2
 ```
+
+#### `client`
+
+Container is `docker/client.Dockerfile`, build with: `docker build -t dnssec-tests-client -f docker/client.Dockerfile docker`, with `tshark`.
+
+Run the client container with extra capabilities
+
+```shell
+docker run --rm -it --cap-add=NET_RAW --cap-add=NET_ADMIN dnssec-tests-client /bin/bash
+```
+
+Then run `tshark` inside the container:
+
+```shell
+tshark -f 'host 172.17.0.3' -O dns
+```
+
+to filter DNS messages for host `172.17.0.3` (`unbound`).

--- a/docker/client.Dockerfile
+++ b/docker/client.Dockerfile
@@ -1,0 +1,4 @@
+FROM ubuntu:22.04
+
+RUN apt-get update && \
+  apt-get install -y dnsutils iputils-ping tshark

--- a/docker/nsd.Dockerfile
+++ b/docker/nsd.Dockerfile
@@ -1,4 +1,4 @@
 FROM ubuntu:22.04
 
 RUN apt-get update && \
-  apt-get install -y nsd
+  apt-get install -y nsd iputils-ping

--- a/docker/unbound.Dockerfile
+++ b/docker/unbound.Dockerfile
@@ -1,4 +1,4 @@
 FROM ubuntu:22.04
 
 RUN apt-get update && \
-  apt-get install -y unbound
+  apt-get install -y unbound iputils


### PR DESCRIPTION
A client based `Dockerfile` is added to run `dig` & `delv` in, to make the setup work on OSX.

* set up client container
* install additional tools
* expand Readme with setup instructions