### PR TITLE
support building hickory from a local/remote git source

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
     branches: [main]
   merge_group:
 
+env:
+  HICKORY_REV: a3669bd80f3f7b97f0c301c15f1cba6368d97b63
+
 jobs:
   ci:
     name: Continuous Integration
@@ -27,7 +30,10 @@ jobs:
         run: cargo test -p conformance-tests -- --include-ignored
 
       - name: Run tests against hickory
-        run: DNS_TEST_SUBJECT=hickory cargo test -p conformance-tests
+        run: |
+          git clone https://github.com/hickory-dns/hickory-dns /tmp/hickory
+          ( cd /tmp/hickory && git reset --hard ${{ env.HICKORY_REV }} )
+          DNS_TEST_SUBJECT="hickory /tmp/hickory" cargo test -p conformance-tests
 
       - name: Check that ignored tests fail with hickory
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@ on:
 
 env:
   HICKORY_REV: a3669bd80f3f7b97f0c301c15f1cba6368d97b63
+  DNS_TEST_VERBOSE_DOCKER_BUILD: 1
 
 jobs:
   ci:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Check that ignored tests fail with hickory
         run: |
           tmpfile="$(mktemp)"
-          DNS_TEST_SUBJECT=hickory cargo test -p conformance-tests -- --ignored | tee "$tmpfile"
+          DNS_TEST_SUBJECT="hickory /tmp/hickory" cargo test -p conformance-tests -- --ignored | tee "$tmpfile"
           grep 'test result: FAILED. 0 passed' "$tmpfile" || ( echo "expected ALL tests to fail but at least one passed; the passing tests must be un-#[ignore]-d" && exit 1 )
 
       - name: Check that code is formatted

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -142,6 +142,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "tempfile",
+ "url",
 ]
 
 [[package]]
@@ -171,6 +172,15 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
+dependencies = [
+ "percent-encoding",
+]
 
 [[package]]
 name = "hashbrown"
@@ -218,6 +228,16 @@ name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
+name = "idna"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
+]
 
 [[package]]
 name = "indexmap"
@@ -303,6 +323,12 @@ name = "once_cell"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+
+[[package]]
+name = "percent-encoding"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "powerfmt"
@@ -479,10 +505,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "unicode-bidi"
+version = "0.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08f95100a766bf4f8f28f90d77e0a5461bbdb219042e7679bebe79004fed8d75"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
+name = "url"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31e6302e3bb753d46e83516cae55ae196fc0c309407cf11ab35cc51a4c2a4633"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+]
 
 [[package]]
 name = "wasm-bindgen"

--- a/packages/dns-test/Cargo.toml
+++ b/packages/dns-test/Cargo.toml
@@ -11,6 +11,7 @@ serde = { version = "1.0.196", features = ["derive"] }
 serde_json = "1.0.113"
 serde_with = "3.6.1"
 tempfile = "3.9.0"
+url = "2.5.0"
 
 [lib]
 doctest = false

--- a/packages/dns-test/src/client.rs
+++ b/packages/dns-test/src/client.rs
@@ -13,7 +13,7 @@ pub struct Client {
 impl Client {
     pub fn new(network: &Network) -> Result<Self> {
         Ok(Self {
-            inner: Container::run(Implementation::Unbound, network)?,
+            inner: Container::run(&Implementation::Unbound, network)?,
         })
     }
 

--- a/packages/dns-test/src/container.rs
+++ b/packages/dns-test/src/container.rs
@@ -57,6 +57,9 @@ impl Container {
                 exec_or_panic(&mut cp_r, false);
             }
 
+            fs::write(docker_build_dir.join(".dockerignore"), "src/.git")
+                .expect("could not create .dockerignore file");
+
             exec_or_panic(&mut command, verbose_docker_build());
         });
 

--- a/packages/dns-test/src/container.rs
+++ b/packages/dns-test/src/container.rs
@@ -37,20 +37,20 @@ impl Container {
             .arg(&image_tag)
             .arg(docker_build_dir);
 
-        let srcdir = if let Implementation::Hickory { url } = implementation {
-            Some(url)
+        let repo = if let Implementation::Hickory(repo) = implementation {
+            Some(repo)
         } else {
             None
         };
 
         implementation.once().call_once(|| {
-            if let Some(srcdir) = srcdir {
+            if let Some(repo) = repo {
                 let mut cp_r = Command::new("git");
                 cp_r.args([
                     "clone",
                     "--depth",
                     "1",
-                    srcdir,
+                    repo.as_str(),
                     &docker_build_dir.join("src").display().to_string(),
                 ]);
 

--- a/packages/dns-test/src/container/network.rs
+++ b/packages/dns-test/src/container/network.rs
@@ -146,7 +146,7 @@ mod tests {
         let network = Network::new().expect("Failed to create network");
         let network_name = network.name().to_string();
         let container =
-            Container::run(Implementation::Unbound, &network).expect("Failed to start container");
+            Container::run(&Implementation::Unbound, &network).expect("Failed to start container");
 
         assert!(exists_network(&network_name));
         drop(network);

--- a/packages/dns-test/src/docker/hickory.Dockerfile
+++ b/packages/dns-test/src/docker/hickory.Dockerfile
@@ -4,5 +4,6 @@ RUN apt-get update && \
     apt-get install -y \
         tshark
 
-RUN cargo install hickory-dns --version 0.24.0 --features recursor --debug
+COPY ./src /usr/src/hickory
+RUN cargo install --path /usr/src/hickory/bin --features recursor --debug
 env RUST_LOG=debug

--- a/packages/dns-test/src/docker/hickory.Dockerfile
+++ b/packages/dns-test/src/docker/hickory.Dockerfile
@@ -4,6 +4,9 @@ RUN apt-get update && \
     apt-get install -y \
         tshark
 
+# `dns-test` will invoke `docker build` from a temporary directory that contains
+# a clone of the hickory repository. `./src` here refers to that clone; not to
+# any directory inside the `dns-test` repository
 COPY ./src /usr/src/hickory
 RUN cargo install --path /usr/src/hickory/bin --features recursor --debug
 env RUST_LOG=debug

--- a/packages/dns-test/src/lib.rs
+++ b/packages/dns-test/src/lib.rs
@@ -1,7 +1,11 @@
 //! A test framework for all things DNS
 
 use core::fmt;
+use std::borrow::Cow;
+use std::path::Path;
 use std::sync::Once;
+
+use url::Url;
 
 pub use crate::container::Network;
 pub use crate::fqdn::FQDN;
@@ -24,7 +28,33 @@ pub mod zone_file;
 #[derive(Clone)]
 pub enum Implementation {
     Unbound,
-    Hickory { url: String },
+    Hickory(Repository<'static>),
+}
+
+#[derive(Clone)]
+pub struct Repository<'a> {
+    inner: Cow<'a, str>,
+}
+
+impl Repository<'_> {
+    fn as_str(&self) -> &str {
+        &self.inner
+    }
+}
+
+/// checks that `input` looks like a valid repository which can be either local or remote
+///
+/// # Panics
+///
+/// this function panics if `input` is not a local `Path` that exists or a well-formed URL
+#[allow(non_snake_case)]
+pub fn Repository(input: impl Into<Cow<'static, str>>) -> Repository<'static> {
+    let input = input.into();
+    assert!(
+        Path::new(&*input).exists() || Url::parse(&input).is_ok(),
+        "{input} is not a valid repository"
+    );
+    Repository { inner: input }
 }
 
 impl Implementation {
@@ -74,9 +104,7 @@ pub fn subject() -> Implementation {
 
         if subject.starts_with("hickory") {
             if let Some(url) = subject.strip_prefix("hickory ") {
-                Implementation::Hickory {
-                    url: url.to_string(),
-                }
+                Implementation::Hickory(Repository(url.to_string()))
             } else {
                 panic!("the syntax of DNS_TEST_SUBJECT is 'hickory $URL', e.g. 'hickory /tmp/hickory' or 'hickory https://github.com/owner/repo'")
             }

--- a/packages/dns-test/src/name_server.rs
+++ b/packages/dns-test/src/name_server.rs
@@ -43,7 +43,7 @@ impl<'a> NameServer<'a, Stopped> {
         });
 
         Ok(Self {
-            container: Container::run(Implementation::Unbound, network)?,
+            container: Container::run(&Implementation::Unbound, network)?,
             zone_file,
             state: Stopped,
         })

--- a/packages/dns-test/src/resolver.rs
+++ b/packages/dns-test/src/resolver.rs
@@ -33,7 +33,7 @@ impl Resolver {
             "must configure at least one local root server"
         );
 
-        let container = Container::run(implementation, network)?;
+        let container = Container::run(&implementation, network)?;
 
         let mut hints = String::new();
         for root in roots {
@@ -51,7 +51,7 @@ impl Resolver {
                 )?;
             }
 
-            Implementation::Hickory => {
+            Implementation::Hickory { .. } => {
                 container.status_ok(&["mkdir", "-p", "/etc/hickory"])?;
 
                 container.cp("/etc/hickory/root.hints", &hints)?;
@@ -66,7 +66,7 @@ impl Resolver {
 
         let command: &[_] = match implementation {
             Implementation::Unbound => &["unbound", "-d"],
-            Implementation::Hickory => &["hickory-dns", "-d"],
+            Implementation::Hickory { .. } => &["hickory-dns", "-d"],
         };
         let child = container.spawn(command)?;
 


### PR DESCRIPTION
this PR also 
- adds a mechanism to make the `docker build` output visible: the DNS_TEST_VERBOSE_DOCKER_BUILD env var
- makes CI run the conformance tests against a git version of hickory pinned to a specific commit hash

closes #10