### PR TITLE
add `dns_test::peer` and use it to initialize `NameServer`

### DIFF
--- a/packages/conformance-tests/src/resolver/dns/scenarios.rs
+++ b/packages/conformance-tests/src/resolver/dns/scenarios.rs
@@ -12,10 +12,11 @@ fn can_resolve() -> Result<()> {
     let needle_fqdn = FQDN("example.nameservers.com.")?;
 
     let network = Network::new()?;
-    let mut root_ns = NameServer::new(FQDN::ROOT, &network)?;
-    let mut com_ns = NameServer::new(FQDN::COM, &network)?;
+    let mut root_ns = NameServer::new(dns_test::peer(), FQDN::ROOT, &network)?;
+    let mut com_ns = NameServer::new(dns_test::peer(), FQDN::COM, &network)?;
 
-    let mut nameservers_ns = NameServer::new(FQDN("nameservers.com.")?, &network)?;
+    let mut nameservers_ns =
+        NameServer::new(dns_test::peer(), FQDN("nameservers.com.")?, &network)?;
     nameservers_ns
         .a(root_ns.fqdn().clone(), root_ns.ipv4_addr())
         .a(com_ns.fqdn().clone(), com_ns.ipv4_addr())
@@ -68,10 +69,11 @@ fn nxdomain() -> Result<()> {
     let needle_fqdn = FQDN("unicorn.nameservers.com.")?;
 
     let network = Network::new()?;
-    let mut root_ns = NameServer::new(FQDN::ROOT, &network)?;
-    let mut com_ns = NameServer::new(FQDN::COM, &network)?;
+    let mut root_ns = NameServer::new(dns_test::peer(), FQDN::ROOT, &network)?;
+    let mut com_ns = NameServer::new(dns_test::peer(), FQDN::COM, &network)?;
 
-    let mut nameservers_ns = NameServer::new(FQDN("nameservers.com.")?, &network)?;
+    let mut nameservers_ns =
+        NameServer::new(dns_test::peer(), FQDN("nameservers.com.")?, &network)?;
     nameservers_ns
         .a(root_ns.fqdn().clone(), root_ns.ipv4_addr())
         .a(com_ns.fqdn().clone(), com_ns.ipv4_addr());

--- a/packages/conformance-tests/src/resolver/dnssec/rfc4035/section_4/section_4_1.rs
+++ b/packages/conformance-tests/src/resolver/dnssec/rfc4035/section_4/section_4_1.rs
@@ -9,7 +9,7 @@ use dns_test::{Network, Resolver, Result, TrustAnchor, FQDN};
 #[ignore]
 fn edns_support() -> Result<()> {
     let network = &Network::new()?;
-    let ns = NameServer::new(FQDN::ROOT, network)?.start()?;
+    let ns = NameServer::new(dns_test::peer(), FQDN::ROOT, network)?.start()?;
     let resolver = Resolver::start(
         dns_test::subject(),
         &[Root::new(ns.fqdn().clone(), ns.ipv4_addr())],

--- a/packages/conformance-tests/src/resolver/dnssec/scenarios.rs
+++ b/packages/conformance-tests/src/resolver/dnssec/scenarios.rs
@@ -11,7 +11,7 @@ use dns_test::{Network, Resolver, Result, TrustAnchor, FQDN};
 #[test]
 fn can_validate_without_delegation() -> Result<()> {
     let network = Network::new()?;
-    let mut ns = NameServer::new(FQDN::ROOT, &network)?;
+    let mut ns = NameServer::new(dns_test::peer(), FQDN::ROOT, &network)?;
     ns.a(ns.fqdn().clone(), ns.ipv4_addr());
     let ns = ns.sign()?;
 
@@ -55,10 +55,11 @@ fn can_validate_with_delegation() -> Result<()> {
     let needle_fqdn = FQDN("example.nameservers.com.")?;
 
     let network = Network::new()?;
-    let mut root_ns = NameServer::new(FQDN::ROOT, &network)?;
-    let mut com_ns = NameServer::new(FQDN::COM, &network)?;
+    let mut root_ns = NameServer::new(dns_test::peer(), FQDN::ROOT, &network)?;
+    let mut com_ns = NameServer::new(dns_test::peer(), FQDN::COM, &network)?;
 
-    let mut nameservers_ns = NameServer::new(FQDN("nameservers.com.")?, &network)?;
+    let mut nameservers_ns =
+        NameServer::new(dns_test::peer(), FQDN("nameservers.com.")?, &network)?;
     nameservers_ns
         .a(root_ns.fqdn().clone(), root_ns.ipv4_addr())
         .a(com_ns.fqdn().clone(), com_ns.ipv4_addr())

--- a/packages/dns-test/src/client.rs
+++ b/packages/dns-test/src/client.rs
@@ -1,10 +1,10 @@
 use core::str::FromStr;
 use std::net::Ipv4Addr;
 
-use crate::container::{Container, Network};
+use crate::container::{Container, Image, Network};
 use crate::record::{Record, RecordType};
 use crate::trust_anchor::TrustAnchor;
-use crate::{Error, Implementation, Result, FQDN};
+use crate::{Error, Result, FQDN};
 
 pub struct Client {
     inner: Container,
@@ -13,7 +13,7 @@ pub struct Client {
 impl Client {
     pub fn new(network: &Network) -> Result<Self> {
         Ok(Self {
-            inner: Container::run(&Implementation::Unbound, network)?,
+            inner: Container::run(&Image::Client, network)?,
         })
     }
 

--- a/packages/dns-test/src/container/network.rs
+++ b/packages/dns-test/src/container/network.rs
@@ -113,7 +113,7 @@ fn network_count() -> usize {
 
 #[cfg(test)]
 mod tests {
-    use crate::{container::Container, Implementation};
+    use crate::container::{Container, Image};
 
     use super::*;
 
@@ -146,7 +146,7 @@ mod tests {
         let network = Network::new().expect("Failed to create network");
         let network_name = network.name().to_string();
         let container =
-            Container::run(&Implementation::Unbound, &network).expect("Failed to start container");
+            Container::run(&Image::Client, &network).expect("Failed to start container");
 
         assert!(exists_network(&network_name));
         drop(network);

--- a/packages/dns-test/src/docker/client.Dockerfile
+++ b/packages/dns-test/src/docker/client.Dockerfile
@@ -1,0 +1,8 @@
+FROM debian:bookworm-slim
+
+# dnsutils = dig & delv
+# iputils-ping = ping
+RUN apt-get update && \
+    apt-get install -y \
+        dnsutils \
+        iputils-ping

--- a/packages/dns-test/src/docker/unbound.Dockerfile
+++ b/packages/dns-test/src/docker/unbound.Dockerfile
@@ -1,12 +1,8 @@
 FROM debian:bookworm-slim
 
-# dnsutils = dig & delv
-# iputils-ping = ping
 # ldns-utils = ldns-{key2ds,keygen,signzone}
 RUN apt-get update && \
     apt-get install -y \
-        dnsutils \
-        iputils-ping \
         ldnsutils \
         nsd \
         tshark \

--- a/packages/dns-test/src/lib.rs
+++ b/packages/dns-test/src/lib.rs
@@ -115,3 +115,7 @@ pub fn subject() -> Implementation {
         Implementation::default()
     }
 }
+
+pub fn peer() -> Implementation {
+    Implementation::default()
+}

--- a/packages/dns-test/src/lib.rs
+++ b/packages/dns-test/src/lib.rs
@@ -1,9 +1,7 @@
 //! A test framework for all things DNS
 
-use core::fmt;
 use std::borrow::Cow;
 use std::path::Path;
-use std::sync::Once;
 
 use url::Url;
 
@@ -57,42 +55,9 @@ pub fn Repository(input: impl Into<Cow<'static, str>>) -> Repository<'static> {
     Repository { inner: input }
 }
 
-impl Implementation {
-    fn dockerfile(&self) -> &'static str {
-        match self {
-            Implementation::Unbound => include_str!("docker/unbound.Dockerfile"),
-            Implementation::Hickory { .. } => include_str!("docker/hickory.Dockerfile"),
-        }
-    }
-
-    fn once(&self) -> &'static Once {
-        match self {
-            Implementation::Unbound => {
-                static UNBOUND_ONCE: Once = Once::new();
-                &UNBOUND_ONCE
-            }
-
-            Implementation::Hickory { .. } => {
-                static HICKORY_ONCE: Once = Once::new();
-                &HICKORY_ONCE
-            }
-        }
-    }
-}
-
 impl Default for Implementation {
     fn default() -> Self {
         Self::Unbound
-    }
-}
-
-impl fmt::Display for Implementation {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let s = match self {
-            Implementation::Unbound => "unbound",
-            Implementation::Hickory { .. } => "hickory",
-        };
-        f.write_str(s)
     }
 }
 

--- a/packages/dns-test/src/name_server.rs
+++ b/packages/dns-test/src/name_server.rs
@@ -25,7 +25,12 @@ impl<'a> NameServer<'a, Stopped> {
     /// - one SOA record, with the primary name server field set to this name server's FQDN
     /// - one NS record, with this name server's FQDN set as the only available name server for
     /// the zone
-    pub fn new(zone: FQDN<'a>, network: &Network) -> Result<Self> {
+    pub fn new(implementation: Implementation, zone: FQDN<'a>, network: &Network) -> Result<Self> {
+        assert!(
+            matches!(implementation, Implementation::Unbound),
+            "currently only `unbound` (`nsd`) can be used as a `NameServer`"
+        );
+
         let ns_count = ns_count();
         let nameserver = primary_ns(ns_count);
 
@@ -301,7 +306,7 @@ mod tests {
     #[test]
     fn simplest() -> Result<()> {
         let network = Network::new()?;
-        let tld_ns = NameServer::new(FQDN::COM, &network)?.start()?;
+        let tld_ns = NameServer::new(Implementation::Unbound, FQDN::COM, &network)?.start()?;
         let ip_addr = tld_ns.ipv4_addr();
 
         let client = Client::new(&network)?;
@@ -322,7 +327,7 @@ mod tests {
     fn with_referral() -> Result<()> {
         let network = Network::new()?;
         let expected_ip_addr = Ipv4Addr::new(172, 17, 200, 1);
-        let mut root_ns = NameServer::new(FQDN::ROOT, &network)?;
+        let mut root_ns = NameServer::new(Implementation::Unbound, FQDN::ROOT, &network)?;
         root_ns.referral(
             FQDN::COM,
             FQDN("primary.tld-server.com.")?,
@@ -351,7 +356,7 @@ mod tests {
     #[test]
     fn signed() -> Result<()> {
         let network = Network::new()?;
-        let ns = NameServer::new(FQDN::ROOT, &network)?.sign()?;
+        let ns = NameServer::new(Implementation::Unbound, FQDN::ROOT, &network)?.sign()?;
 
         eprintln!("KSK:\n{}", ns.key_signing_key());
         eprintln!("ZSK:\n{}", ns.zone_signing_key());
@@ -387,7 +392,7 @@ mod tests {
     #[test]
     fn terminate_works() -> Result<()> {
         let network = Network::new()?;
-        let ns = NameServer::new(FQDN::ROOT, &network)?.start()?;
+        let ns = NameServer::new(Implementation::Unbound, FQDN::ROOT, &network)?.start()?;
         let logs = ns.terminate()?;
 
         assert!(logs.contains("nsd starting"));

--- a/packages/dns-test/src/name_server.rs
+++ b/packages/dns-test/src/name_server.rs
@@ -47,8 +47,9 @@ impl<'a> NameServer<'a, Stopped> {
             nameserver: nameserver.clone(),
         });
 
+        let image = implementation.into();
         Ok(Self {
-            container: Container::run(&Implementation::Unbound, network)?,
+            container: Container::run(&image, network)?,
             zone_file,
             state: Stopped,
         })

--- a/packages/dns-test/src/resolver.rs
+++ b/packages/dns-test/src/resolver.rs
@@ -120,7 +120,7 @@ mod tests {
     #[test]
     fn terminate_works() -> Result<()> {
         let network = Network::new()?;
-        let ns = NameServer::new(FQDN::ROOT, &network)?.start()?;
+        let ns = NameServer::new(Implementation::Unbound, FQDN::ROOT, &network)?.start()?;
         let resolver = Resolver::start(
             Implementation::Unbound,
             &[Root::new(ns.fqdn().clone(), ns.ipv4_addr())],

--- a/packages/dns-test/src/resolver.rs
+++ b/packages/dns-test/src/resolver.rs
@@ -33,7 +33,8 @@ impl Resolver {
             "must configure at least one local root server"
         );
 
-        let container = Container::run(&implementation, network)?;
+        let image = implementation.clone().into();
+        let container = Container::run(&image, network)?;
 
         let mut hints = String::new();
         for root in roots {

--- a/packages/dns-test/src/tshark.rs
+++ b/packages/dns-test/src/tshark.rs
@@ -255,7 +255,7 @@ mod tests {
     #[test]
     fn nameserver() -> Result<()> {
         let network = &Network::new()?;
-        let ns = NameServer::new(FQDN::ROOT, network)?.start()?;
+        let ns = NameServer::new(Implementation::Unbound, FQDN::ROOT, network)?.start()?;
         let mut tshark = ns.eavesdrop()?;
 
         let client = Client::new(network)?;
@@ -291,10 +291,11 @@ mod tests {
     #[test]
     fn resolver() -> Result<()> {
         let network = &Network::new()?;
-        let mut root_ns = NameServer::new(FQDN::ROOT, network)?;
-        let mut com_ns = NameServer::new(FQDN::COM, network)?;
+        let mut root_ns = NameServer::new(Implementation::Unbound, FQDN::ROOT, network)?;
+        let mut com_ns = NameServer::new(Implementation::Unbound, FQDN::COM, network)?;
 
-        let mut nameservers_ns = NameServer::new(FQDN("nameservers.com.")?, network)?;
+        let mut nameservers_ns =
+            NameServer::new(Implementation::Unbound, FQDN("nameservers.com.")?, network)?;
         nameservers_ns
             .a(root_ns.fqdn().clone(), root_ns.ipv4_addr())
             .a(com_ns.fqdn().clone(), com_ns.ipv4_addr());


### PR DESCRIPTION
also create a new `Client` docker image to reduce the footprint of the `Unbound` image