### PR TITLE
fix the explore example

### DIFF
--- a/packages/dns-test/examples/explore.rs
+++ b/packages/dns-test/examples/explore.rs
@@ -8,15 +8,16 @@ use dns_test::{Network, Resolver, Result, TrustAnchor, FQDN};
 
 fn main() -> Result<()> {
     let network = Network::new()?;
+    let peer = dns_test::peer();
 
     println!("building docker image...");
-    let mut root_ns = NameServer::new(FQDN::ROOT, &network)?;
+    let mut root_ns = NameServer::new(peer.clone(), FQDN::ROOT, &network)?;
     println!("DONE");
 
     println!("setting up name servers...");
-    let mut com_ns = NameServer::new(FQDN::COM, &network)?;
+    let mut com_ns = NameServer::new(peer.clone(), FQDN::COM, &network)?;
 
-    let mut nameservers_ns = NameServer::new(FQDN("nameservers.com.")?, &network)?;
+    let mut nameservers_ns = NameServer::new(peer.clone(), FQDN("nameservers.com.")?, &network)?;
     nameservers_ns
         .a(root_ns.fqdn().clone(), root_ns.ipv4_addr())
         .a(com_ns.fqdn().clone(), com_ns.ipv4_addr());


### PR DESCRIPTION
branch protection did not require CI to run on PR rebased on top of latest code so it didn't catch this when #18 and #19 were merged 